### PR TITLE
Fix/alt

### DIFF
--- a/kirbyDatasCleaner.tsx
+++ b/kirbyDatasCleaner.tsx
@@ -138,14 +138,15 @@ export const languageParser: any = (languages: Language[], domain?: string, slug
 }
 
 export const fixAlt = (image: any) => {
-  const newImage = {
-    ...image,
-    content: {
-      ...image.content,
-      alt: image.info
-    }
-  }
-  return newImage
+  return image
+    ? {
+        ...image,
+        content: {
+          ...image.content,
+          alt: image.info
+        }
+      }
+    : null
 }
 
 export const flattenImages = (obj: any) => {

--- a/src/blocks/Timeline.tsx
+++ b/src/blocks/Timeline.tsx
@@ -18,7 +18,7 @@ const TimelineItem: React.VFC<{item: TimelineItemProps; last: boolean}> = ({item
       </div>
       <div className="flex flex-col sm:flex-row w-full gap-4">
         <div className="sm:w-1/3 sm:order-last">
-          {item.image && (
+          {item?.image && (
             <Media
               media={item.image}
               autoplay={true}


### PR DESCRIPTION
This extracts the `alt` text from the `info` field, based on this advice: https://forum.getkirby.com/t/how-can-i-get-my-images-alt-texts-from-within-my-vue-components/23918/10?u=shawninder

The alt text is inserted into the `info` field via https://github.com/tjikko-studio/SMPX-Backend/pull/151